### PR TITLE
Users don't usually want -Werror

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,6 +1,6 @@
 ACEUNIT_HOME?=../
 CPPFLAGS+=-I$(ACEUNIT_HOME)/include/
-CFLAGS+=-W -Wall -pedantic -Werror
+CFLAGS+=-W -Wall -pedantic
 ACEUNIT:=$(ACEUNIT_HOME)/bin/aceunit
 
 .PHONY: all


### PR DESCRIPTION
- Remove `-Werror` from `lib/Makefile`
- Wasn't sure, didn't change `test/special/c90_bool/Makefile`
- `compiler-test-%` (for project maintainers) already includes `-Werror`