### PR TITLE
Fix misspelling in bin/aceunit

### DIFF
--- a/bin/aceunit
+++ b/bin/aceunit
@@ -190,7 +190,7 @@ generateExterns() {
     done
 }
 
-generateFxitureStructures() {
+generateFixtureStructures() {
     for file in $fixtures; do
         basename=$(getBasename $file)
         echo
@@ -229,7 +229,7 @@ END
 generateFixtures() {
     generateHeader
     generateExterns
-    generateFxitureStructures
+    generateFixtureStructures
     generateFixtureTable
 }
 


### PR DESCRIPTION
## Summary
- correct the generateFixtureStructures function name in `bin/aceunit`
- update call site in `generateFixtures`

## Testing
- `make -C test/generatorTests`
- `make -C lib test`
- `make -C test > /tmp/make_test.log 2>&1 && tail -n 20 /tmp/make_test.log`

------
https://chatgpt.com/codex/tasks/task_e_6856de1e5280832e8af128f28b57524a