### PR TITLE
Fix case in lib Makefile

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -57,7 +57,7 @@ test/%_Fixture.c: test/%_Test.o
 
 # Don't delete this. It looks redundant only when building in lib/.
 # But when building somewhere else with vpath set, this is important.
-test/AceUnit_SimpleRunner_Test.o test/AceUnit_AbortRunner_Test.o test/AceUnit_ForkRunner_Test.o test/AceUnit_SetJmpRunner_test.o: | test/
+test/AceUnit_SimpleRunner_Test.o test/AceUnit_AbortRunner_Test.o test/AceUnit_ForkRunner_Test.o test/AceUnit_SetJmpRunner_Test.o: | test/
 test/:
 	mkdir -p $@
 


### PR DESCRIPTION
## Summary
- fix filename in dependency list so `test/` gets created for SetJmpRunner tests

## Testing
- `make -C lib test`


------
https://chatgpt.com/codex/tasks/task_e_6856de21d9f8832e9d8e52a93757d99e